### PR TITLE
Added Tekton trigger to handle comments with /recheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A PR check run that ensures requirements are met before allowing PRs to be merge
 
 - Configure a list of PR Checks that must all be successful before merging
 - Allow skipping these checks by placing a `skip/ci` label on the PR
+- Force a recheck by adding a comment to a PR containing the trigger `/recheck`
 
 ## How it works
 

--- a/tekton/trigger.yaml
+++ b/tekton/trigger.yaml
@@ -44,3 +44,51 @@ spec:
       kind: ClusterTriggerBinding
   template:
     ref: pr-gatekeeper
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: pr-gatekeeper-recheck
+  labels:
+    app: pr-gatekeeper
+    app.kubernetes.io/name: pr-gatekeeper
+    app.kubernetes.io/component: trigger
+    app.kubernetes.io/instance: pr-gatekeeper-recheck
+    app.kubernetes.io/part-of: pr-gatekeeper
+    application.giantswarm.io/team: team-tinkerers
+  annotations:
+    tekton.dev/tags: github, pull request
+    giantswarm.io/notes: |
+      Triggers pr-gatekeeper to run when a comment with `/recheck` is added to a PR
+spec:
+  name: github-pr
+  interceptors:
+    - ref:
+        name: "github"
+      params:
+        - name: "eventTypes"
+          value: ["issue_comment"]
+        - name: "secretRef"
+          value:
+            secretName: github-webhook-secret
+            secretKey: token
+    - name: contains-trigger-keyword
+      ref:
+        name: "cel"
+      params:
+      - name: filter
+        value: "body.action in ['created', 'edited'] && body.comment.body != null && body.comment.body.indexOf('/recheck') >= 0"
+    - name: add-pr-number
+      ref:
+        name: "cel"
+      params:
+        - name: "overlays"
+          value:
+          - key: pr_number
+            expression: "body.issue.number"
+  bindings:
+    - ref: pr-gatekeeper
+      kind: ClusterTriggerBinding
+  template:
+    ref: pr-gatekeeper
+---


### PR DESCRIPTION
Allow re-triggering the pr-gatekeeper checks with a comment on PRs containing `/recheck`. This would allow to get around transient errors such as the previous task failing to run due to cluster environment problems.