### PR TITLE
Add support for adding a hold label to PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added the commit hash to the details to make it clearer its not related to the PR as a whole
+* Added support for the `do-not-merge/hold` label to block merging.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A PR check run that ensures requirements are met before allowing PRs to be merge
 
 - Configure a list of PR Checks that must all be successful before merging
 - Allow skipping these checks by placing a `skip/ci` label on the PR
+- Allow blocking PR merge by adding a `do-not-merge/hold` label on the PR
 - Force a recheck by adding a comment to a PR containing the trigger `/recheck`
 
 ## How it works
@@ -16,6 +17,7 @@ A PR check run that ensures requirements are met before allowing PRs to be merge
 4. Upon start `pr-gatekeeper` creates a new Check Run on the PR called `Heimdall - PR Gatekeeper` in an in-progress state.
 5. The repos configuration will be loaded from [`config.yaml`](./config.yaml) and will confirm that the required PR checks are in a successful state. If they are, the `Heimdall - PR Gatekeeper` PR check is update to completed successfuly. If the checks haven't completed then the `Heimdall - PR Gatekeeper` PR check remains in-progress.
 6. If the PR has the `skip/ci` label then all required checks will be ignored and the PR will be allowed to be merged.
+7. If the PR has the `do-not-merge/hold` label then the PR will be blocked from merging until this label is removed from the PR regardless of the other conditions being met.
 
 ## Releasing a new version
 

--- a/internal/results/results.go
+++ b/internal/results/results.go
@@ -1,0 +1,32 @@
+package results
+
+import "strings"
+
+type Result struct {
+	ChecksPassing bool
+	SkipCI        bool
+	HoldPR        bool
+	Messages      []string
+}
+
+func New() *Result {
+	return &Result{
+		ChecksPassing: true,
+		SkipCI:        false,
+		HoldPR:        false,
+		Messages:      []string{},
+	}
+}
+
+// AllowAccess returns true if checks are passing (or SkipCI is set) and the PR is not marked as hold
+func (r *Result) AllowAccess() bool {
+	return (r.ChecksPassing || r.SkipCI) && !r.HoldPR
+}
+
+func (r *Result) AddMessage(msg string) {
+	r.Messages = append(r.Messages, msg)
+}
+
+func (r *Result) GetMessages() string {
+	return strings.Join(r.Messages, "\n")
+}


### PR DESCRIPTION
### What does this PR do?

* Adds support for using a `do-not-merge/hold` label on PRs to block merging until it is removed.
* Refactored the result logic to be more flexible

- [x] CHANGELOG.md has been updated (if it exists)
