### PR TITLE
Support label overrides without repo-specific config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * If the test is one we know the trigger for we add a note on how to trigger it
 * If test is found but not yet completed we add a "... but is still in progress" message (not shown here)
 * If a test is found to have failed we add a "... but didn't complete successfully" message (not shown here)
+* Label overrides can be used even if repo doesn't have any config setup

--- a/cmd/gatekeeper/main.go
+++ b/cmd/gatekeeper/main.go
@@ -86,19 +86,19 @@ func main() {
 				result.AddMessage(fmt.Sprintf("⚠️ Check Run `%s` is required but didn't completed successfully%s\n", check, trigger))
 			}
 		}
+	}
 
-		// Check labels on the PR for overriding behaviour
-		for _, label := range pullRequest.Labels {
-			switch strings.ToLower(*label.Name) {
-			case skipLabel:
-				result.SkipCI = true
-				result.AddMessage(fmt.Sprintf("ℹ️ Pull Requests contains the `%s` label - **ignoring other requirements**", skipLabel))
-			case doNotMergeHold:
-				result.HoldPR = true
-				result.AddMessage(fmt.Sprintf("⛔️ Pull Requests contains the `%s` label - **blocking merge until removed**", doNotMergeHold))
-			default:
-				continue
-			}
+	// Check labels on the PR for overriding behaviour
+	for _, label := range pullRequest.Labels {
+		switch strings.ToLower(*label.Name) {
+		case skipLabel:
+			result.SkipCI = true
+			result.AddMessage(fmt.Sprintf("ℹ️ Pull Requests contains the `%s` label - **ignoring other requirements**", skipLabel))
+		case doNotMergeHold:
+			result.HoldPR = true
+			result.AddMessage(fmt.Sprintf("⛔️ Pull Requests contains the `%s` label - **blocking merge until removed**", doNotMergeHold))
+		default:
+			continue
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

Allows the use of labels to mark a PR as on-hold or skip without there needing to be any repo-specific config setup.