### PR TITLE
Added mc-bootstrap required checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added the commit hash to the details to make it clearer its not related to the PR as a whole
 * Added support for the `do-not-merge/hold` label to block merging.
+* Added `mc-bootstrap` required checks
 
 ### Changed
 

--- a/config.yaml
+++ b/config.yaml
@@ -42,3 +42,9 @@ repos:
     requiredChecks:
       - "E2E Test Suites"
       - "Foo Bar"
+
+  mc-bootstrap:
+    requiredChecks:
+      - "Generate MC - capa / goten"
+      - "Generate MC - capz / goose"
+      # - "Generate MC - vsphere / gmc" # Not required until more stable


### PR DESCRIPTION
### What does this PR do?

Adds required GitHub checks to `mc-bootstrap` PRs.

Currently the vsphere check is commented out until it's more reliable.