### PR TITLE
Added SkipDocsOnly config property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added the commit hash to the details to make it clearer its not related to the PR as a whole
 * Added support for the `do-not-merge/hold` label to block merging.
 * Added `mc-bootstrap` required checks
+* `SkipDocsOnly` repo config boolean for skipping CI when only Markdown files have changed.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A PR check run that ensures requirements are met before allowing PRs to be merge
 - Allow skipping these checks by placing a `skip/ci` label on the PR
 - Allow blocking PR merge by adding a `do-not-merge/hold` label on the PR
 - Force a recheck by adding a comment to a PR containing the trigger `/recheck`
+- Configure PR Checks as not required when a PR only contains markdown changes by setting the `skipDocsOnly` config property
 
 ## How it works
 

--- a/cmd/gatekeeper/main.go
+++ b/cmd/gatekeeper/main.go
@@ -88,6 +88,24 @@ func main() {
 		}
 	}
 
+	if repoConfig.SkipDocsOnly {
+		fmt.Println("`SkipDocsOnly` is set to true, checking for changed file types")
+		files, err := gh.GetFiles()
+		if err != nil {
+			fmt.Println("Failed to get PRs files")
+			panic(err)
+		}
+		for _, file := range files {
+			fileName := strings.ToLower(file.GetFilename())
+			if !strings.HasSuffix(fileName, ".md") {
+				fmt.Printf("Non-markdown file found ('%s'), not skipping\n", fileName)
+				break
+			}
+		}
+		result.SkipCI = true
+		result.AddMessage("ℹ️ Pull Requests only contains Markdown changes and `skipDocsOnly` is set - **ignoring other requirements**")
+	}
+
 	// Check labels on the PR for overriding behaviour
 	for _, label := range pullRequest.Labels {
 		switch strings.ToLower(*label.Name) {

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -16,6 +16,7 @@ type Repos map[string]Repo
 
 type Repo struct {
 	RequiredChecks []string `json:"requiredChecks"`
+	SkipDocsOnly   bool     `json:"skipDocsOnly"`
 }
 
 func LoadConfig() (*Conf, error) {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -107,3 +107,30 @@ func (c *Client) GetCheck(checkName string) (*github.CheckRun, error) {
 	}
 	return checks.CheckRuns[0], nil
 }
+
+func (c *Client) GetFiles() ([]*github.CommitFile, error) {
+	prNumber, err := strconv.Atoi(c.PR)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := &github.ListOptions{
+		PerPage: 100,
+	}
+
+	var allFiles []*github.CommitFile
+	for {
+		files, resp, err := c.PullRequests.ListFiles(c.Ctx, owner, c.Repo, prNumber, opts)
+		if err != nil {
+			return nil, err
+		}
+		allFiles = append(allFiles, files...)
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return allFiles, nil
+}


### PR DESCRIPTION
### What does this PR do?

Introduces a new `skipDocsOnly` repo config property that can be set to `true` to allow for skipping the CI check requirements if a PR contains only changes to `*.md` files.