### PR TITLE
Added ignoreFilesMatch config property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added the commit hash to the details to make it clearer its not related to the PR as a whole
 * Added support for the `do-not-merge/hold` label to block merging.
 * Added `mc-bootstrap` required checks
+* `ignoreFilesMatch` repo config regex to ignore files matching
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A PR check run that ensures requirements are met before allowing PRs to be merge
 - Allow skipping these checks by placing a `skip/ci` label on the PR
 - Allow blocking PR merge by adding a `do-not-merge/hold` label on the PR
 - Force a recheck by adding a comment to a PR containing the trigger `/recheck`
+- Configure files to ignore requiring checks for by providing a filename regex to `ignoreFilesMatch`
 
 ## How it works
 

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -15,7 +15,8 @@ type KnownTriggers map[string]string
 type Repos map[string]Repo
 
 type Repo struct {
-	RequiredChecks []string `json:"requiredChecks"`
+	RequiredChecks   []string `json:"requiredChecks"`
+	IgnoreFilesMatch string   `json:"ignoreFilesMatch"`
 }
 
 func LoadConfig() (*Conf, error) {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -107,3 +107,30 @@ func (c *Client) GetCheck(checkName string) (*github.CheckRun, error) {
 	}
 	return checks.CheckRuns[0], nil
 }
+
+func (c *Client) GetFiles() ([]*github.CommitFile, error) {
+	prNumber, err := strconv.Atoi(c.PR)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := &github.ListOptions{
+		PerPage: 100,
+	}
+
+	var allFiles []*github.CommitFile
+	for {
+		files, resp, err := c.PullRequests.ListFiles(c.Ctx, owner, c.Repo, prNumber, opts)
+		if err != nil {
+			return nil, err
+		}
+		allFiles = append(allFiles, files...)
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return allFiles, nil
+}


### PR DESCRIPTION
### What does this PR do?

Introduces a new `ignoreFilesMatch` repo config property that can be provided with a regex that will be used to filter our files changed in a PR. If there a no files left in the PR after all matches have been removed than the requirement on the PR checks will be skipped. 

This allows for ignoring the PR checks for things like documentation changes using a value like: `(/docs)?/.+\.md$`