### PR TITLE
Bump architect orb to latest with Go 1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@4.29.0
+  architect: giantswarm/architect@4.30.1
 
 workflows:
   build-and-publish:


### PR DESCRIPTION
Blocked by https://github.com/giantswarm/architect-orb/pull/422 followed by a new minor release.