### PR TITLE
Require CAPV tests for mc-bootstrap

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -47,4 +47,4 @@ repos:
     requiredChecks:
       - "Generate MC - capa / goten"
       - "Generate MC - capz / goose"
-      # - "Generate MC - vsphere / gmc" # Not required until more stable
+      - "Generate MC - vsphere / gmc"


### PR DESCRIPTION
### What does this PR do?

Re-enables requiring CAPV tests to pass for mc-bootstrap PRs
