### PR TITLE
Migrated image registry to use ACR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * If a test is found to have failed we add a "... but didn't complete successfully" message (not shown here)
 * Label overrides can be used even if repo doesn't have any config setup
 * Bumped Go to v1.20
+* Migrated image registry to ACR

--- a/tekton/task.yaml
+++ b/tekton/task.yaml
@@ -28,7 +28,7 @@ spec:
   # Optional
   - name: IMAGE
     type: string
-    default: "quay.io/giantswarm/pr-gatekeeper:latest"
+    default: "gsoci.azurecr.io/giantswarm/pr-gatekeeper:latest"
 
   - name: GITHUB_TOKEN_SECRET
     type: string


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/29214

Switches the image registry from Quay to ACR.