### PR TITLE
Added securityContext to Tekton Tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added the commit hash to the details to make it clearer its not related to the PR as a whole
 * Added support for the `do-not-merge/hold` label to block merging.
 * Added `mc-bootstrap` required checks
+* Added `securityContext` to Tekton Tasks
 
 ### Changed
 

--- a/tekton/task.yaml
+++ b/tekton/task.yaml
@@ -35,6 +35,18 @@ spec:
     description: The name of the secret containing the GitHub authentication credentials.
     default: tinkerers-ci-github-token
 
+  stepTemplate:
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+
   steps:
     - name: heimdall
       image: $(params.IMAGE)

--- a/tekton/trigger-template.yaml
+++ b/tekton/trigger-template.yaml
@@ -30,5 +30,11 @@ spec:
         - name: REPO
           value: $(tt.params.REPO)
         podTemplate:
+          securityContext:
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
           imagePullSecrets:
             - name: quay-imagepull-secret


### PR DESCRIPTION
### What does this PR do?

Adds `securityContext` to the Tekton tasks.

Towads: https://github.com/giantswarm/giantswarm/issues/29723 and https://github.com/giantswarm/giantswarm/issues/29113