### PR TITLE
Exclude GitHub actions from triggering pr-gatekeeper

### DIFF
--- a/tekton/trigger.yaml
+++ b/tekton/trigger.yaml
@@ -30,7 +30,7 @@ spec:
         name: "cel"
       params:
       - name: filter
-        value: "has(body.check_run) ? body.check_run.name != 'Heimdall - PR Gatekeeper' : true"
+        value: "has(body.check_run) ? (body.check_run.name != 'Heimdall - PR Gatekeeper && body.check_run.app.slug != 'github-actions') : true"
     - name: add-pr-number
       ref:
         name: "cel"


### PR DESCRIPTION
### What does this PR do?

Ignores any checkruns that are from github-actions as we don't check for any of those with pr-gatekeeper.

Towards: https://github.com/giantswarm/giantswarm/issues/29853