### PR TITLE
Bump Dockerfile to Go v1.21 to match go.mod 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.20-alpine as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.21-alpine as builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
The dockerfile version wasn't inline with the go.mod