### PR TITLE
upgrade v1beta1 to v1 api version

### DIFF
--- a/tekton/task.yaml
+++ b/tekton/task.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: pr-gatekeeper


### PR DESCRIPTION
### What does this PR do?

This change upgrades the api version to v1 from v1beta1 for tekton resources.

Based on [this guide](https://github.com/tektoncd/pipeline/blob/main/docs/migrating-v1beta1-to-v1.md) no change except the api version is required.

 issue: https://github.com/giantswarm/giantswarm/issues/30166

### What is the effect of this change to users?

### How does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated (if it exists)
