### PR TITLE
Added releases test suite as required for releases repo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,6 @@
 knownTriggers:
   "E2E Test Suites": "/run cluster-test-suites"
+  "Release Test Suites": "/run releases-test-suites"
 
 repos:
   cluster-test-suites:
@@ -49,3 +50,7 @@ repos:
       - "Generate MC - capz / goose"
       - "Generate MC - vsphere / gmc"
       - "Generate MC - cloud-director / goshawk"
+
+  releases:
+    requiredChecks:
+      - "Release Test Suites"


### PR DESCRIPTION
Set Heimdall to block PRs on `giantswarm/releases` that don't have a passing `Release Test Suites` check.