### PR TITLE
Replace the skip/ci label functionality with a /skip-ci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added support for the `do-not-merge/hold` label to block merging.
 * Added `mc-bootstrap` required checks
 * Added `securityContext` to Tekton Tasks
+* Implement support for `/skip-ci [reason]` comment trigger to replace old `skip/ci` label
 
 ### Changed
 
@@ -29,3 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Bumped Go to v1.20
 * Migrated image registry to ACR
 * Automatically add "E2E Test Suites" required check when ./tests/e2e/config.yaml present in repo.
+
+### Removed
+
+* Removed support of using the `skip/ci` label for bypassing the gatekeeper - replaced with the `/skip-ci [reason]` comment trigger

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/google/go-github/v70/github"
 	"golang.org/x/oauth2"
@@ -17,8 +18,7 @@ const (
 
 var (
 	checkName = "Heimdall - PR Gatekeeper"
-	imageURL  = "https://github.com/giantswarm/pr-gatekeeper/assets/3384072/6c85d6be-6726-446c-ab37-c6c26601aec9"
-	imageAlt  = "Heimdall"
+	imageHTML = `<img src="https://github.com/giantswarm/pr-gatekeeper/assets/3384072/6c85d6be-6726-446c-ab37-c6c26601aec9" height="100px" alt="Heimdall" />`
 )
 
 type Client struct {
@@ -55,12 +55,34 @@ func (c *Client) GetPR() (*github.PullRequest, error) {
 	return pullRequest, err
 }
 
+func (c *Client) GetPRComments() ([]*github.IssueComment, error) {
+	prNumber, err := strconv.Atoi(c.PR)
+	if err != nil {
+		return nil, err
+	}
+	comments, _, err := c.Issues.ListComments(c.Ctx, owner, c.Repo, prNumber, &github.IssueListCommentsOptions{ListOptions: github.ListOptions{PerPage: 500}})
+	return comments, err
+}
+
+func (c *Client) GetLastCommitTimestamp() (*github.Timestamp, error) {
+	prNumber, err := strconv.Atoi(c.PR)
+	if err != nil {
+		return nil, err
+	}
+	commits, _, err := c.PullRequests.ListCommits(c.Ctx, owner, c.Repo, prNumber, &github.ListOptions{PerPage: 500})
+	if err != nil {
+		return nil, err
+	}
+	latestCommit := commits[len(commits)-1]
+	return latestCommit.Commit.Committer.Date, nil
+}
+
 func (c *Client) AddCheck(pending bool, msg string) error {
 	status := "in_progress"
-	summary := "PR currently blocked from merging"
+	summary := "🚧 PR currently blocked from merging\n\n" + imageHTML
 	if !pending {
 		status = "completed"
-		summary = "PR meets all defined requirements for merging"
+		summary = "✅ PR meets all defined requirements for merging\n\n" + imageHTML
 	}
 
 	msg += "\n\n---\n_Source: https://github.com/giantswarm/pr-gatekeeper_\n_Repo Config: https://github.com/giantswarm/pr-gatekeeper/blob/main/config.yaml_"
@@ -74,12 +96,7 @@ func (c *Client) AddCheck(pending bool, msg string) error {
 			Title:   &checkName,
 			Summary: &summary,
 			Text:    &msg,
-			Images: []*github.CheckRunImage{
-				{
-					Alt:      &imageAlt,
-					ImageURL: &imageURL,
-				},
-			},
+			Images:  []*github.CheckRunImage{},
 		},
 	})
 	return err
@@ -130,4 +147,128 @@ func (c *Client) GetFile(filepath string) (string, bool, error) {
 	}
 
 	return body, true, nil
+}
+
+func (c *Client) AddSkippingComment(reason, user string) error {
+	prNumber, err := strconv.Atoi(c.PR)
+	if err != nil {
+		return err
+	}
+
+	hiddenTag := "<!-- CI SKIP COMMENT -->"
+	commentMessage := fmt.Sprintf("🚨 **CI checks were skipped**\n\nSkip reason: `%s`\nSkipped by: @%s\n%s", reason, user, hiddenTag)
+
+	// We need to first check for old comments and mark them as outdated to avoid noise
+	comments, err := c.GetPRComments()
+	if err != nil {
+		return err
+	}
+
+	if len(comments) > 0 {
+		lastComment := comments[len(comments)-1]
+		if lastComment.Body != nil && *lastComment.Body == commentMessage {
+			// The last comment on the PR is already our skip message
+			return nil
+		}
+
+		for _, comment := range comments {
+			if comment.Body != nil && strings.Contains(*comment.Body, hiddenTag) {
+				query := `
+					mutation minimizeComment($id: ID!, $classifier: ReportedContentClassifiers!) {
+						minimizeComment(input: { subjectId: $id, classifier: $classifier }) {
+							clientMutationId
+							minimizedComment {
+								isMinimized
+								minimizedReason
+								viewerCanMinimize
+							}
+						}
+					}
+				`
+				variables := map[string]interface{}{
+					"id":         comment.NodeID,
+					"classifier": "OUTDATED",
+				}
+
+				req, _ := c.NewRequest("POST", "https://api.github.com/graphql", map[string]interface{}{
+					"query":     query,
+					"variables": variables,
+				})
+				var result map[string]interface{}
+				_, err := c.Do(c.Ctx, req, &result)
+				if err != nil {
+					fmt.Println("Failed to mark comment as outdated")
+				}
+			}
+		}
+	}
+
+	_, _, err = c.Client.Issues.CreateComment(c.Ctx, owner, c.Repo, prNumber, &github.IssueComment{Body: &commentMessage})
+	return err
+}
+
+func (c *Client) AddReasonRequiredComment() error {
+	prNumber, err := strconv.Atoi(c.PR)
+	if err != nil {
+		return err
+	}
+
+	hiddenTag := "<!-- REASON REQUIRED -->"
+	commentMessage := fmt.Sprintf("🚨 A reason is required when using the `/skip-ci` comment - e.g. `/skip-ci Test environment is currently down`\n%s", hiddenTag)
+
+	// We need to first check for old comments and delete them to avoid noise
+	comments, err := c.GetPRComments()
+	if err != nil {
+		return err
+	}
+
+	if len(comments) > 0 {
+		lastComment := comments[len(comments)-1]
+		if lastComment.Body != nil && *lastComment.Body == commentMessage {
+			// The last comment on the PR is already our skip message
+			return nil
+		}
+
+		for _, comment := range comments {
+			if comment.Body != nil && strings.Contains(*comment.Body, hiddenTag) {
+				_, _ = c.Issues.DeleteComment(c.Ctx, owner, c.Repo, *comment.ID)
+			}
+		}
+	}
+
+	_, _, err = c.Client.Issues.CreateComment(c.Ctx, owner, c.Repo, prNumber, &github.IssueComment{Body: &commentMessage})
+	return err
+}
+
+func (c *Client) AddSkipLabelDeprecatedComment() error {
+	prNumber, err := strconv.Atoi(c.PR)
+	if err != nil {
+		return err
+	}
+
+	hiddenTag := "<!-- SKIP LABEL DEPRECATED -->"
+	commentMessage := fmt.Sprintf("ℹ️ Please note: The `skip/ci` label no longer controls skipping the CI checks and is now purely informational.\n\nPlease use the `/skip-ci [reason]` comment trigger with a required reason message.\n%s", hiddenTag)
+
+	// We need to first check for old comments and delete them to avoid noise
+	comments, err := c.GetPRComments()
+	if err != nil {
+		return err
+	}
+
+	if len(comments) > 0 {
+		lastComment := comments[len(comments)-1]
+		if lastComment.Body != nil && *lastComment.Body == commentMessage {
+			// The last comment on the PR is already our skip message
+			return nil
+		}
+
+		for _, comment := range comments {
+			if comment.Body != nil && strings.Contains(*comment.Body, hiddenTag) {
+				_, _ = c.Issues.DeleteComment(c.Ctx, owner, c.Repo, *comment.ID)
+			}
+		}
+	}
+
+	_, _, err = c.Client.Issues.CreateComment(c.Ctx, owner, c.Repo, prNumber, &github.IssueComment{Body: &commentMessage})
+	return err
 }

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -272,3 +272,23 @@ func (c *Client) AddSkipLabelDeprecatedComment() error {
 	_, _, err = c.Client.Issues.CreateComment(c.Ctx, owner, c.Repo, prNumber, &github.IssueComment{Body: &commentMessage})
 	return err
 }
+
+func (c *Client) AddSkipCILabel() error {
+	prNumber, err := strconv.Atoi(c.PR)
+	if err != nil {
+		return err
+	}
+
+	_, _, err = c.Client.Issues.AddLabelsToIssue(c.Ctx, owner, c.Repo, prNumber, []string{"skip/ci"})
+	return err
+}
+
+func (c *Client) RemoveSkipCILabel() error {
+	prNumber, err := strconv.Atoi(c.PR)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.Client.Issues.RemoveLabelForIssue(c.Ctx, owner, c.Repo, prNumber, "skip/ci")
+	return err
+}


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/32898

This PR:
* Removes the ability to skip the pr-gatekeeper check by applying the `skip/ci` label
* Adds a new `/skip-ci [reason]` comment trigger that should be used now to skip the gatekeeper with a required reason message

Example PRs:
* https://github.com/giantswarm/tinkerers-ci-test-1/pull/33
* https://github.com/giantswarm/tinkerers-ci-test-1/pull/34