### PR TITLE
feat: require the E2E Coverage check on releases PRs

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -12,6 +12,10 @@ CVE-2026-46598 until=2026-07-29 # golang.org/x/crypto@v0.51.0
 CVE-2026-39827 until=2026-07-29 # golang.org/x/crypto@v0.51.0
 CVE-2026-39828 until=2026-07-29 # golang.org/x/crypto@v0.51.0
 CVE-2026-48978 until=2026-08-02 # oras.land/oras-go/v2@v2.6.0
+# helm.sh/helm/v4 is pulled in transitively via apptest-framework. The fix is only in
+# upstream commit ba6c9a2 and no release contains it yet (v4.2.3 is the latest), so there
+# is nothing to bump to. Only affects chart rendering, which this app does not do.
+CVE-2026-63308 until=2026-09-04 # helm.sh/helm/v4@v4.2.3
 CVE-2026-50151 until=2026-08-02 # oras.land/oras-go/v2@v2.6.0
 CVE-2026-50162 until=2026-08-02 # oras.land/oras-go/v2@v2.6.0
 CVE-2026-50163 until=2026-08-02 # oras.land/oras-go/v2@v2.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Require the `E2E Coverage` check on `releases` PRs, so a release is only mergeable once every expected test suite has passed and not just the ones the current release stage runs.
 * Require a successful `Generate MC` (MC creation test) for at least one provider updated in a `releases` PR before it can be merged.
 * Added the commit hash to the details to make it clearer its not related to the PR as a whole
 * Added support for the `do-not-merge/hold` label to block merging.

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,7 @@
 knownTriggers:
   "E2E Test Suites": "/run cluster-test-suites"
   "Release Test Suites": "/run releases-test-suites"
+  "E2E Coverage": "/run releases-test-suites"
 
 repos:
   cluster-test-suites:
@@ -60,3 +61,7 @@ repos:
   releases:
     requiredChecks:
       - "Release Test Suites"
+      # Requires the full set of test suites for every new release in the PR, not just the
+      # ones the current release stage happens to run. Published by the `E2E Coverage`
+      # workflow in giantswarm/releases.
+      - "E2E Coverage"


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4334

Adds `E2E Coverage` to the required checks for `giantswarm/releases`, so a release can only be merged once every expected test suite has passed rather than just the suites the current stage happens to run.

The check is published by giantswarm/releases#2400, which must be merged first — otherwise this requires a check that nothing publishes and blocks every releases PR.

Also ignores `CVE-2026-63308` (`helm.sh/helm/v4@v4.2.3`, pulled in transitively via apptest-framework) to get CI green. The fix is only in upstream commit `ba6c9a2` and no release contains it yet, so there is nothing to bump to. It affects chart rendering, which this app does not do.